### PR TITLE
Debug token error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,15 @@
 	"type": "phpcodesniffer-standard",
 	"require": {
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
-		"squizlabs/php_codesniffer": "^3.4.0",
+		"squizlabs/php_codesniffer": "^3.9.0",
 		"slevomat/coding-standard": "^8.14",
 		"php": ">=7.4"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^9.5",
+		"phpunit/phpunit": "^9.6",
 		"donatj/drop": "^1.0",
 		"friendsofphp/php-cs-fixer": "^3.14",
+		"nikic/php-parser": "^4",
 		"ext-dom": "*"
 	},
 	"authors": [


### PR DESCRIPTION
`nikic/php-parser` >= 5 and `squizlabs/php_codesniffer` [are incompatible](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/357)…

@todo - figure out how `slevomat/coding-standard` seems to be handling it?